### PR TITLE
Update loader-utils dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "pretest" : "semistandard | snazzy",
     "test"    : "mocha"
   },
-  "dependencies": { "loader-utils": "0.2.x" },
+  "dependencies": { "loader-utils": "0.2.16" },
   "devDependencies": {
     "chai"         : "3.5.x",
     "mocha"        : "3.2.x",


### PR DESCRIPTION
The original package.json depends on "loader-utils" version 0.2.x.

But the last version of this series (0.2.17) emits an annoying warning for every webpack build:
> DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
> parseQuery() will be replaced with getOptions() in the next major version of loader-utils.

Instead of updating this dependency to a major new version (which may require code changes),
this quick-fix simply locks the dependency to 0.2.16, which is the last-but-one of the series,
and which does not emit that warning.